### PR TITLE
use getMetadataFor() method

### DIFF
--- a/src/Normalizer/DoctrineNormalizer.php
+++ b/src/Normalizer/DoctrineNormalizer.php
@@ -52,6 +52,6 @@ class DoctrineNormalizer implements NormalizerInterface, DenormalizerInterface
 
     private function hasMetadataFor($class)
     {
-        return $this->objectManager->getMetadataFactory()->hasMetadataFor($class);
+        return (bool) $this->objectManager->getMetadataFactory()->getMetadataFor($class);
     }
 }


### PR DESCRIPTION
hasMetadataFor() only works if the metadata has already been loaded
