### PR TITLE
Allow denormalize for null

### DIFF
--- a/src/Normalizer/RecursiveReflectionNormalizer.php
+++ b/src/Normalizer/RecursiveReflectionNormalizer.php
@@ -71,6 +71,7 @@ class RecursiveReflectionNormalizer extends AggregateNormalizer implements Aggre
     {
         switch (true) {
             case is_scalar($data):
+            case null === $data:
                 return $data;
 
             case is_array($data):


### PR DESCRIPTION
`null` is not a scalar, so on denormalize I get :

```
Warning: ReflectionObject::__construct() expects parameter 1 to be object, null given in vendor/bernard/normalt/src/Normalizer/RecursiveReflectionNormalizer.php line 31
```